### PR TITLE
Fix off-by-one allocation error

### DIFF
--- a/common.c
+++ b/common.c
@@ -40,8 +40,8 @@ int set_card_info() {
     card_info.pin_length = strlen(pin);
     card_info.id_length = sizeof(id);
 
-    card_info.pin = malloc( card_info.pin_length );
-    card_info.change_pin = malloc( card_info.pin_length );
+    card_info.pin = malloc( card_info.pin_length + 1 );
+    card_info.change_pin = malloc( card_info.pin_length + 1 );
 
 
     if(!card_info.pin || !card_info.change_pin)


### PR DESCRIPTION
Allocation of N bytes and then writing to position N in char array is out-of-bounds access.
